### PR TITLE
Support injecting a boto3 client / session factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Optionally, you can also customize the `is_retry` argument name. `refresh_on_err
 * **error_callback** (default: `None`)
 * **retry_argument** (default: `"is_retry"`)
 
+## Replacing the SSM client
+
+If you want to replace the default `boto3` SSM client, `SSMParameter` and `SSMParameterGroup` both support calling `set_ssm_client` with an object that implements the SSM `get_parameters` method. There is an example of doing this for testing in `tests/override_test.py`.
+
 ## How to contribute
 
 Clone this repository, create a virtualenv and install all the dev dependencies:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ nose==1.3.7
 Pygments==2.2.0
 pypandoc==1.4
 coveralls==1.2.0
+placebo==0.8.1

--- a/ssm_cache/cache.py
+++ b/ssm_cache/cache.py
@@ -132,7 +132,7 @@ class SSMParameter(Refreshable):
     def _refresh(self):
         """ Force refresh of the configured param names """
         if self._group:
-            return self._group.refresh()
+            self._group.refresh()
 
         values, invalid_parameters = self._get_parameters([self._name], self._with_decryption)
         if invalid_parameters:

--- a/ssm_cache/cache.py
+++ b/ssm_cache/cache.py
@@ -5,15 +5,27 @@ from datetime import datetime, timedelta
 from functools import wraps
 import six
 
-import boto3
-
 class InvalidParameterError(Exception):
     """ Raised when something's wrong with the provided param name """
 
 class Refreshable(object):
     """ Abstract class for refreshable objects (with max-age) """
 
-    ssm_client = boto3.client('ssm')
+    _ssm_client = None
+
+    @classmethod
+    def set_ssm_client(cls, client):
+        """Override the default boto3 SSM client with your own."""
+        if not 'get_parameters' in dir(client):
+            raise TypeError('client must have a get_parameters method')
+        cls._ssm_client = client
+
+    @classmethod
+    def _get_ssm_client(cls):
+        if cls._ssm_client is None:
+            import boto3
+            cls._ssm_client = boto3.client('ssm')
+        return cls._ssm_client
 
     def __init__(self, max_age):
         self._last_refresh_time = None
@@ -44,7 +56,7 @@ class Refreshable(object):
         values = {}
         invalid_names = []
         for name_batch in _batch(names, 10): # can only get 10 parameters at a time
-            response = cls.ssm_client.get_parameters(
+            response = cls._get_ssm_client().get_parameters(
                 Names=list(name_batch),
                 WithDecryption=with_decryption,
             )

--- a/tests/override_test.py
+++ b/tests/override_test.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+import sys
+
+import boto3
+import placebo
+
+from mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from ssm_cache import SSMParameter
+
+class TestClientOverride(unittest.TestCase):
+    def testWithPlacebo(self):
+        session = boto3.Session()
+        pill = placebo.attach(session, data_path=os.path.abspath(os.path.join(os.path.dirname(__file__), 'placebo')))
+        pill.playback()
+
+        client = session.client('ssm')
+
+        SSMParameter.set_ssm_client(client)
+
+        cache = SSMParameter("my_param")
+        self.assertEqual(cache.value, "expected value")
+
+        # reset to a proper client
+        SSMParameter.set_ssm_client(boto3.Session().client('ssm'))
+
+    def testWithIllegalClient(self):
+        with self.assertRaises(TypeError):
+            SSMParameter.set_ssm_client(42)

--- a/tests/placebo/ssm.GetParameters_1.json
+++ b/tests/placebo/ssm.GetParameters_1.json
@@ -1,0 +1,14 @@
+{
+    "status_code": 200,
+    "data": {
+        "InvalidParameters": [],
+        "Parameters": [
+            {
+                "Version": 1,
+                "Type": "String",
+                "Name": "my_param",
+                "Value": "expected value"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- As suggested by @benkehoe, brings in support for a user to replace the
  default boto3 client and session with a factory; this can be used for
  testing or other interesting purposes.

- Based on the implementation in iRobotCorporation/cfn-custom-resource.

Fixes alexcasalboni/ssm-cache-python#4.