### PR TITLE
Extract SSM store, add environment + chained stores

### DIFF
--- a/ssm_cache/__init__.py
+++ b/ssm_cache/__init__.py
@@ -1,2 +1,2 @@
 """ Expose 'cache' submodule classes """
-from ssm_cache.cache import SSMParameter, SSMParameterGroup, InvalidParameterError
+from ssm_cache.cache import Parameter, ParameterGroup, InvalidParameterError

--- a/ssm_cache/__init__.py
+++ b/ssm_cache/__init__.py
@@ -1,2 +1,2 @@
 """ Expose 'cache' submodule classes """
-from ssm_cache.cache import Parameter, ParameterGroup, InvalidParameterError
+from ssm_cache.cache import SSMParameter, SSMParameterGroup, InvalidParameterError

--- a/ssm_cache/cache.py
+++ b/ssm_cache/cache.py
@@ -1,4 +1,4 @@
-""" Cache module that implements the parameter caching wrapper """
+""" Cache module that implements the SSM caching wrapper """
 from __future__ import absolute_import, print_function
 
 from datetime import datetime, timedelta
@@ -68,21 +68,21 @@ class Refreshable(object):
             return wrapped
         return true_decorator
 
-class ParameterGroup(Refreshable):
-    """ Concrete class that wraps multiple parameters """
+class SSMParameterGroup(Refreshable):
+    """ Concrete class that wraps multiple SSM Parameters """
 
     def __init__(self, max_age=None, with_decryption=True, store=None):
-        super(ParameterGroup, self).__init__(max_age, store)
+        super(SSMParameterGroup, self).__init__(max_age, store)
 
         self._with_decryption = with_decryption
         self._parameters = {}
 
     def parameter(self, name):
-        """ Create a new Parameter by name (or retrieve an existing one) """
+        """ Create a new SSMParameter by name (or retrieve an existing one) """
         if name in self._parameters:
             return self._parameters[name]
-        parameter = Parameter(name)
-        parameter._group = self  # pylint: disable=protected-access
+        parameter = SSMParameter(name)
+        parameter._group = self # pylint: disable=protected-access
         self._parameters[name] = parameter
         return parameter
 
@@ -100,11 +100,11 @@ class ParameterGroup(Refreshable):
     def __len__(self):
         return len(self._parameters)
 
-class Parameter(Refreshable):
-    """ Concrete class for an individual parameter """
+class SSMParameter(Refreshable):
+    """ Concrete class for an individual SSM parameter """
 
     def __init__(self, param_name, max_age=None, with_decryption=True, store=None):
-        super(Parameter, self).__init__(max_age, store)
+        super(SSMParameter, self).__init__(max_age, store)
         if not param_name:
             raise ValueError("Must specify name")
         self._name = param_name

--- a/ssm_cache/chain.py
+++ b/ssm_cache/chain.py
@@ -1,0 +1,29 @@
+"""Parameter store that reads from the provided set of backing stores."""
+from __future__ import absolute_import, print_function
+
+from .store import ParameterStore
+from .env import EnvironmentParameterStore
+from .ssm import SSMParameterStore
+
+class ChainedParameterStore(ParameterStore): # pylint: disable=too-few-public-methods
+    """Concrete ParameterStore that reads from the provided set of backing stores."""
+
+    def __init__(self, stores=None):
+        if stores is None:
+            self._stores = [EnvironmentParameterStore(), SSMParameterStore()]
+        else:
+            self._stores = stores
+
+    def parameters(self, names, with_decryption):
+        """Retrieve the named parameters from the chain of stores. """
+        values = {}
+        invalid_names = names
+
+        for store in self._stores:
+            cur_values, invalid_names = store.parameters(invalid_names, with_decryption)
+            values.update(cur_values)
+
+            if not invalid_names:
+                break
+
+        return values, invalid_names

--- a/ssm_cache/env.py
+++ b/ssm_cache/env.py
@@ -1,0 +1,26 @@
+"""Parameter store that reads from the environment"""
+from __future__ import absolute_import, print_function
+
+import os
+
+from .store import ParameterStore
+
+class EnvironmentParameterStore(ParameterStore): # pylint: disable=too-few-public-methods
+    """Concrete ParameterStore that reads from OS environment variables."""
+
+    def __init__(self, prefix=None):
+        self._prefix = "" if prefix is None else prefix
+
+    def parameters(self, names, with_decryption):
+        """Retrieve the named parameters from OS environment variables."""
+        values = {}
+        invalid_names = []
+        for name in names:
+            prefixed_name = (self._prefix + name).upper()
+
+            if prefixed_name in os.environ:
+                values[name] = os.environ[prefixed_name]
+            else:
+                invalid_names.append(name)
+
+        return values, invalid_names

--- a/ssm_cache/ssm.py
+++ b/ssm_cache/ssm.py
@@ -66,8 +66,8 @@ class SSMParameterStore(ParameterStore): # pylint: disable=too-few-public-method
             cls._CLIENT = client
         return cls._CLIENT
 
-    @classmethod
-    def _batch(cls, iterable, num):
+    @staticmethod
+    def _batch(iterable, num):
         """Turn an iterable into an iterable of batches of size n (or less, for the last one)"""
         length = len(iterable)
         for ndx in range(0, length, num):

--- a/ssm_cache/ssm.py
+++ b/ssm_cache/ssm.py
@@ -1,0 +1,89 @@
+"""Parameter store that reads from AWS Systems Manager Parameter Store"""
+from __future__ import absolute_import, print_function
+
+from .store import ParameterStore
+
+class SSMParameterStore(ParameterStore): # pylint: disable=too-few-public-methods
+    """Concrete ParameterStore that reads from AWS Systems Manager Parameter Store
+
+    The class provides an _ssm_client() method that caches the client in the class,
+    reducing overhead in the Lambda invocations. These relies on the _session() method,
+    which in turn uses SESSION_FACTORY if it is set, allowing overriding with mock sessions
+    for testing. Similarly, CLIENT_FACTORY can be set to a callable that take a session and a name
+    to override client creation.
+
+    Some hooks are provided to override behavior. These are class fields, since they are called
+    by a class method.
+    * SESSION_FACTORY takes no input and returns an object that acts like a boto3 session.
+        If this class field is not None, it is used by _session() instead of creating
+        a regular boto3 session. This could be made to use placebo for testing
+        https://github.com/garnaat/placebo
+    * BOTO3_CLIENT_FACTORY takes the AWS service name (as defined in boto3) as input and returns
+    * CLIENT_FACTORY takes the AWS service name (as defined in boto3) as input and returns
+        an object that acts like a boto3 client. If this class field is not None, it is used by
+        get_boto3_client() instead of creating a regular boto3 client.
+    """
+
+    @classmethod
+    def _default_session_factory(cls):
+        """Default session factory that creates a boto3 session."""
+        import boto3
+        return boto3.session.Session()
+
+    @classmethod
+    def _default_client_factory(cls, session, name):
+        """Default client factory that creates a client from the provided session."""
+        return session.client(name)
+
+    SESSION_FACTORY = _default_session_factory
+    CLIENT_FACTORY = _default_client_factory
+
+    _SESSION = None
+    _CLIENT = None
+
+    @classmethod
+    def _session(cls):
+        """Use the defined session factory to create an object that acts like a boto3 session.
+        Defaults to boto3.session.Session(); set SESSION_FACTORY to inject a different session
+        factory."""
+        if cls._SESSION is None:
+            if cls.SESSION_FACTORY:
+                cls._SESSION = cls.SESSION_FACTORY()
+            else:
+                cls._SESSION = cls._default_session_factory()
+        return cls._SESSION
+
+    @classmethod
+    def _client(cls):
+        """Use the defined client factory to create an object that acts like a boto3 client.
+        Defaults to _session().client("ssm"); set CLIENT_FACTORY to inject a different client
+        factory."""
+        if cls._CLIENT is None:
+            if cls.CLIENT_FACTORY:
+                client = cls.CLIENT_FACTORY(cls._session(), "ssm")
+            else:
+                client = cls._default_client_factory(cls._session(), "ssm")
+            cls._CLIENT = client
+        return cls._CLIENT
+
+    @classmethod
+    def _batch(cls, iterable, num):
+        """Turn an iterable into an iterable of batches of size n (or less, for the last one)"""
+        length = len(iterable)
+        for ndx in range(0, length, num):
+            yield iterable[ndx:min(ndx + num, length)]
+
+    def parameters(self, names, with_decryption):
+        """Retrieve the named parameters from the AWS Systems Manager Parameter Store."""
+        values = {}
+        invalid_names = []
+        for name_batch in self._batch(names, 10): # can only get 10 parameters at a time
+            response = self._client().get_parameters(
+                Names=list(name_batch),
+                WithDecryption=with_decryption,
+            )
+            invalid_names.extend(response['InvalidParameters'])
+            for item in response['Parameters']:
+                values[item['Name']] = item['Value']
+
+        return values, invalid_names

--- a/ssm_cache/store.py
+++ b/ssm_cache/store.py
@@ -1,0 +1,9 @@
+""" Generic parameter store abstract class """
+from __future__ import absolute_import, print_function
+
+class ParameterStore(object): # pylint: disable=too-few-public-methods
+    """ Abstract class for parameter stores """
+    @classmethod
+    def parameters(cls, names, with_decryption):
+        """ Get the named parameters from the store """
+        raise NotImplementedError

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -7,7 +7,7 @@ from moto import mock_ssm
 from . import TestBase
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from ssm_cache import Parameter, ParameterGroup, InvalidParameterError
+from ssm_cache import SSMParameter, SSMParameterGroup, InvalidParameterError
 from ssm_cache.cache import Refreshable
 from ssm_cache.ssm import SSMParameterStore
 from ssm_cache.env import EnvironmentParameterStore
@@ -18,7 +18,7 @@ class AlternateStore(object):
         return {names[0]: "alternative"}, []
 
 @mock_ssm
-class TestCache(TestBase):
+class TestSSMCache(TestBase):
 
     def setUp(self):
         names = ["my_param", "my_param_1", "my_param_2", "my_param_3"]
@@ -26,17 +26,17 @@ class TestCache(TestBase):
 
     def test_creation(self):
         # single string
-        cache = Parameter("my_param")
+        cache = SSMParameter("my_param")
         self.assertTrue(cache._with_decryption)
         self.assertIsNone(cache._max_age)
         self.assertIsNone(cache._last_refresh_time)
         # invalid params
         with self.assertRaises(TypeError):
-            Parameter()
+            SSMParameter()
         with self.assertRaises(ValueError):
-            Parameter(None)
+            SSMParameter(None)
         
-        group = ParameterGroup()
+        group = SSMParameterGroup()
         parameter = group.parameter("my_param")
         with self.assertRaises(TypeError):
             group.parameter()
@@ -61,17 +61,17 @@ class TestCache(TestBase):
             cache.refresh()
 
     def test_main(self):
-        cache = Parameter("my_param")
+        cache = SSMParameter("my_param")
         my_value = cache.value
         self.assertEqual(my_value, self.PARAM_VALUE)
 
     def test_unexisting(self):
-        cache = Parameter("my_param_invalid_name")
+        cache = SSMParameter("my_param_invalid_name")
         with self.assertRaises(InvalidParameterError):
             cache.value
 
     def test_unexisting_in_group(self):
-        group = ParameterGroup()
+        group = SSMParameterGroup()
         param_1 = group.parameter("my_param_1")
         param_2 = group.parameter("my_param_unexisting")
         with self.assertRaises(InvalidParameterError):
@@ -79,17 +79,17 @@ class TestCache(TestBase):
 
 
     def test_main_with_expiration(self):
-        cache = Parameter("my_param", max_age=300)  # 5 minutes expiration time
+        cache = SSMParameter("my_param", max_age=300)  # 5 minutes expiration time
         my_value = cache.value
         self.assertEqual(my_value, self.PARAM_VALUE)
 
     def test_main_without_encryption(self):
-        cache = Parameter("my_param", with_decryption=False)
+        cache = SSMParameter("my_param", with_decryption=False)
         my_value = cache.value
         self.assertEqual(my_value, self.PARAM_VALUE)
 
     def test_main_with_param_group(self):
-        group = ParameterGroup()
+        group = SSMParameterGroup()
         param_1 = group.parameter("my_param_1")
         param_2 = group.parameter("my_param_2")
         param_3 = group.parameter("my_param_3")
@@ -102,13 +102,13 @@ class TestCache(TestBase):
         self.assertEqual(my_value_3, self.PARAM_VALUE)
 
     def test_group_same_name(self):
-        group = ParameterGroup()
+        group = SSMParameterGroup()
         param_1 = group.parameter("my_param_1")
         param_1_again = group.parameter("my_param_1")
         self.assertEqual(1, len(group))
 
     def test_main_with_explicit_refresh(self):
-        cache = Parameter("my_param")  # will not expire
+        cache = SSMParameter("my_param")  # will not expire
 
         class InvalidCredentials(Exception):
             pass
@@ -127,7 +127,7 @@ class TestCache(TestBase):
             do_something()  # won't fail anymore
 
     def test_main_with_explicit_refresh_of_group(self):
-        group = ParameterGroup()  # will not expire
+        group = SSMParameterGroup()  # will not expire
         param_1 = group.parameter("my_param_1")
         param_2 = group.parameter("my_param_2")
 
@@ -150,7 +150,7 @@ class TestCache(TestBase):
             self.assertEqual(param_2.value, NEW_VALUE)
 
     def test_main_with_explicit_refresh_of_group_param(self):
-        group = ParameterGroup()  # will not expire
+        group = SSMParameterGroup()  # will not expire
         param_1 = group.parameter("my_param_1")
         param_2 = group.parameter("my_param_2")
 
@@ -173,7 +173,7 @@ class TestCache(TestBase):
             self.assertEqual(param_2.value, NEW_VALUE)
 
     def test_main_lambda_handler(self):
-        cache = Parameter("my_param")
+        cache = SSMParameter("my_param")
 
         def lambda_handler(event, context):
             secret_value = cache.value
@@ -186,15 +186,15 @@ class TestCache(TestBase):
     @patch('ssm_cache.ssm.SSMParameterStore._SESSION', new=None)
     @patch('ssm_cache.ssm.SSMParameterStore._CLIENT', new=None)
     def test_session_factory(self):
-        cache = Parameter("my_param")
+        cache = SSMParameter("my_param")
         my_value = cache.value
         self.assertEqual(my_value, self.PARAM_VALUE)
 
     def test_alternative_store(self):
-        cache = Parameter("test", store=AlternateStore)
+        cache = SSMParameter("test", store=AlternateStore)
         self.assertEqual(cache.value, "alternative")
 
     def test_env_store(self):
         os.environ["PREFIX___TEST"] = "my_value"
-        cache = Parameter("test", store=EnvironmentParameterStore("PREFIX___"))
+        cache = SSMParameter("test", store=EnvironmentParameterStore("PREFIX___"))
         self.assertEqual(cache.value, "my_value")

--- a/tests/chain_test.py
+++ b/tests/chain_test.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+from . import TestBase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from ssm_cache.env import EnvironmentParameterStore
+from ssm_cache.chain import ChainedParameterStore
+
+class AlternativeStore(object):
+    @classmethod
+    def parameters(cls, names, with_decryption):
+        return {names[0]: "alternative"}, []
+
+class TestChainedParameterStore(TestBase):
+    def test(self):
+        store = ChainedParameterStore(stores=[EnvironmentParameterStore("___TEST_PREFIX__"), AlternativeStore])
+
+        values, invalid_names = store.parameters(["test"], False)
+
+        self.assertEquals(0, len(invalid_names))
+        self.assertEquals("alternative", values["test"])

--- a/tests/decorator_test.py
+++ b/tests/decorator_test.py
@@ -6,7 +6,7 @@ from moto import mock_ssm
 from . import TestBase
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from ssm_cache import Parameter, ParameterGroup, InvalidParameterError
+from ssm_cache import SSMParameter, SSMParameterGroup, InvalidParameterError
 
 class MySpecialError(Exception):
     """ Just for testing """
@@ -17,8 +17,8 @@ class TestCacheDecorator(TestBase):
     def setUp(self):
         names = ["my_param", "my_grouped_param"]
         self._create_params(names)
-        self.cache = Parameter("my_param")
-        self.group = ParameterGroup()
+        self.cache = SSMParameter("my_param")
+        self.group = SSMParameterGroup()
         self.grouped_param = self.group.parameter("my_grouped_param")
 
     def test_decorator_simple(self):

--- a/tests/decorator_test.py
+++ b/tests/decorator_test.py
@@ -6,19 +6,19 @@ from moto import mock_ssm
 from . import TestBase
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from ssm_cache import SSMParameter, SSMParameterGroup, InvalidParameterError
+from ssm_cache import Parameter, ParameterGroup, InvalidParameterError
 
 class MySpecialError(Exception):
     """ Just for testing """
 
 @mock_ssm
-class TestSSMCacheDecorator(TestBase):
+class TestCacheDecorator(TestBase):
 
     def setUp(self):
         names = ["my_param", "my_grouped_param"]
         self._create_params(names)
-        self.cache = SSMParameter("my_param")
-        self.group = SSMParameterGroup()
+        self.cache = Parameter("my_param")
+        self.group = ParameterGroup()
         self.grouped_param = self.group.parameter("my_grouped_param")
 
     def test_decorator_simple(self):

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from . import TestBase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from ssm_cache.env import EnvironmentParameterStore
+
+class TestEnvironmentParameterStore(TestBase):
+    def test_invalid_parameters(self):
+        store = EnvironmentParameterStore("___TEST_PREFIX___")
+
+        values, invalid_names = store.parameters(["test"], False)
+
+        self.assertEquals(0, len(values))
+        self.assertEquals(1, len(invalid_names))
+        self.assertEquals("test", invalid_names[0])
+
+    def test_valid_parameters(self):
+        os.environ["___TEST_PREFIX___TEST"] = "exists"
+        store = EnvironmentParameterStore("___TEST_PREFIX___")
+
+        values, invalid_names = store.parameters(["test"], False)
+
+        self.assertEquals(1, len(values))
+        self.assertEquals(0, len(invalid_names))
+        self.assertEquals("exists", values["test"])

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -1,0 +1,16 @@
+
+import os
+import sys
+
+from . import TestBase
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from ssm_cache.store import ParameterStore
+
+class TestParameterStore(TestBase):
+    def test_not_implemented(self):
+        try:
+            ParameterStore.parameters([], False)
+            self.assertEqual("expected exception", "did not get one")
+        except NotImplementedError:
+            pass


### PR DESCRIPTION
- SSM parameter store is now in its own class.

- Added an environment parameter store that reads from the OS
  environment, optionally with a prefix.

- Added a chained store (now the default) that will first look
  at the environment and then use SSM as a backup for parameters
  that are not found.

Fixes alexcasalboni/ssm-cache-python#3.