### PR TITLE
Convert StringList parameters to python lists

### DIFF
--- a/ssm_cache/cache.py
+++ b/ssm_cache/cache.py
@@ -63,6 +63,8 @@ class Refreshable(object):
             invalid_names.extend(response['InvalidParameters'])
             for item in response['Parameters']:
                 values[item['Name']] = item['Value']
+                if item['Type'] == 'StringList':
+                    values[item['Name']] = values[item['Name']].split(',')
 
         return values, invalid_names
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,13 +7,16 @@ class TestBase(unittest.TestCase):
     """ Base class with mock values and boto3 client """
 
     PARAM_VALUE = "abc123"
+    PARAM_LIST_COUNT = 2
     ssm_client = boto3.client('ssm')
 
-    def _create_params(self, names, value=PARAM_VALUE):
+    def _create_params(self, names, value=PARAM_VALUE, parameter_type="String"):
+        if parameter_type == 'StringList' and not isinstance(value, list):
+            value = ",".join([value] * self.PARAM_LIST_COUNT)
         for name in names:
             self.ssm_client.put_parameter(
                 Name=name,
                 Value=value,
-                Type="String",
+                Type=parameter_type,
                 Overwrite=True,
             )

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -85,11 +85,25 @@ class TestSSMCache(TestBase):
 
     def test_string_list(self):
         """ Test StringList expiration """
-        cache = SSMParameter("my_params_list")
-        my_values = cache.value
-        self.assertTrue(isinstance(my_values, list))
-        self.assertEqual(len(my_values), self.PARAM_LIST_COUNT)
-        for value in my_values:
+        param = SSMParameter("my_params_list")
+        values = param.value
+        self.assertTrue(isinstance(values, list))
+        self.assertEqual(len(values), self.PARAM_LIST_COUNT)
+        for value in values:
+            self.assertEqual(value, self.PARAM_VALUE)
+
+    def test_group_string_list(self):
+        """ Test StringList expiration """
+        group = SSMParameterGroup()
+
+        my_param = group.parameter("my_param_1")
+        self.assertEqual(my_param.value, self.PARAM_VALUE)
+
+        my_params_list = group.parameter("my_params_list")
+        values = my_params_list.value
+        self.assertTrue(isinstance(values, list))
+        self.assertEqual(len(values), self.PARAM_LIST_COUNT)
+        for value in values:
             self.assertEqual(value, self.PARAM_VALUE)
 
     def test_with_expiration(self):

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -21,6 +21,8 @@ class TestSSMCache(TestBase):
     def setUp(self):
         names = ["my_param", "my_param_1", "my_param_2", "my_param_3"]
         self._create_params(names)
+        list_names = ["my_params_list"]
+        self._create_params(names=list_names, parameter_type="StringList")
 
     def test_creation(self):
         """ Test regular creation """
@@ -81,6 +83,14 @@ class TestSSMCache(TestBase):
         with self.assertRaises(InvalidParameterError):
             group.refresh()
 
+    def test_string_list(self):
+        """ Test StringList expiration """
+        cache = SSMParameter("my_params_list")
+        my_values = cache.value
+        self.assertTrue(isinstance(my_values, list))
+        self.assertEqual(len(my_values), self.PARAM_LIST_COUNT)
+        for value in my_values:
+            self.assertEqual(value, self.PARAM_VALUE)
 
     def test_with_expiration(self):
         """ Test simple case with expiration """


### PR DESCRIPTION
Implements #17 in the simplest way I could think of.

fyi @benkehoe 

The intended use case for this will be something like:

```python
twitter_params = SSMParameter('my_twitter_api_keys')
key, secret, access_token, access_token_secret = twitter_params.value
```

It doesn't really make a big difference wrt

```python
key, secret, access_token, access_token_secret = twitter_params.value.split(',')
```

but it's something you don't want to write over and over (or forget!).