### PR TITLE
Add type hints and ship a py.typed marker (PEP 561)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,17 @@ jobs:
           python-version: "3.13"
           cache: pip
 
-      - name: Install ruff
-        run: pip install "ruff>=0.15"
+      - name: Install ruff and mypy
+        run: pip install "ruff>=0.15" "mypy>=1.11"
 
       - name: Check formatting
         run: ruff format --check .
 
       - name: Check lint
         run: ruff check .
+
+      - name: Check types
+        run: mypy
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Test files mirror the package modules:
 * **version 3.0.0**: 
   * dropped support for Python <3.8
   * Python 3.8–3.13 supported and tested
+  * fully type-annotated; ships a `py.typed` marker (PEP 561) and is type-checked with mypy
   * split monolithic `cache.py` into logically grouped modules (`exceptions`, `filters`, `groups`, `parameters`, `refreshable`, `utils`)
   * `__version__` added to package
   * `pyproject.toml` replaces `setup.py` and `requirements*.txt`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,15 @@ dev = [
     "placebo>=0.10.0",
     # code quality
     "ruff>=0.15",
+    "mypy>=1.11",
     "coveralls>=4.0",
 ]
 
 [tool.setuptools.packages.find]
 exclude = ["tests*"]
+
+[tool.setuptools.package-data]
+ssm_cache = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths   = ["tests"]
@@ -80,3 +84,13 @@ select = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.mypy]
+files = ["ssm_cache"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+# boto3/botocore are imported lazily and ship limited type information
+module = ["boto3.*", "botocore.*"]
+ignore_missing_imports = true

--- a/ssm_cache/filters.py
+++ b/ssm_cache/filters.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
 class SSMFilter:
     KEY_NAME = "Name"
     KEY_TYPE = "Type"
@@ -17,14 +23,14 @@ class SSMFilter:
     OPTION_ALLOWED_VALUES = (OPTION_EQUALS, OPTION_BEGINSWITH)
     OPTION_PATH_ALLOWED_VALUES = (OPTION_RECURSIVE, OPTION_ONELEVEL)
 
-    def __init__(self, key, option=OPTION_EQUALS):
+    def __init__(self, key: str, option: str = OPTION_EQUALS) -> None:
         self._validate_config(key, option)
         self._key = key
         self._option = option
-        self._values = set()
+        self._values: set[str] = set()
 
     @classmethod
-    def _validate_config(cls, key, option):
+    def _validate_config(cls, key: str, option: str) -> None:
         if key not in cls.KEY_ALLOWED_VALUES:
             raise ValueError(f"Invalid key value: {key}")
         if key != cls.KEY_PATH and option not in cls.OPTION_ALLOWED_VALUES:
@@ -32,19 +38,19 @@ class SSMFilter:
         if key == cls.KEY_PATH and option not in cls.OPTION_PATH_ALLOWED_VALUES:
             raise ValueError(f"Invalid option value for Path key: {option}")
 
-    def value(self, value):
+    def value(self, value: str) -> SSMFilter:
         if len(self._values) == 50:
             raise ValueError("You can't set more than 50 values for each filter.")
         self._values.add(value)
         return self  # chainable
 
-    def values(self, values):
+    def values(self, values: Iterable[str]) -> SSMFilter:
         for value in values:
             self.value(value)
         return self  # chainable
 
-    def to_dict(self):
-        filter_dict = {
+    def to_dict(self) -> dict[str, Any]:
+        filter_dict: dict[str, Any] = {
             "Key": self._key,
             "Option": self._option,
         }
@@ -54,7 +60,7 @@ class SSMFilter:
 
 
 class SSMFilterName(SSMFilter):
-    def __init__(self, option=SSMFilter.OPTION_EQUALS):
+    def __init__(self, option: str = SSMFilter.OPTION_EQUALS) -> None:
         super().__init__(self.KEY_NAME, option)
         raise NotImplementedError("Not implemented yet (by AWS)")
 
@@ -65,21 +71,21 @@ class SSMFilterType(SSMFilter):
     TYPE_SECURESTRING = "SecureString"
     TYPE_ALLOWED_VALUES = (TYPE_STRING, TYPE_STRINGLIST, TYPE_SECURESTRING)
 
-    def __init__(self, option=SSMFilter.OPTION_EQUALS):
+    def __init__(self, option: str = SSMFilter.OPTION_EQUALS) -> None:
         super().__init__(self.KEY_TYPE, option)
 
-    def value(self, value):
+    def value(self, value: str) -> SSMFilter:
         if value not in self.TYPE_ALLOWED_VALUES:
             raise ValueError(f"Invalid value for Type filter: {value}")
         return super().value(value)
 
 
 class SSMFilterKeyId(SSMFilter):
-    def __init__(self, option=SSMFilter.OPTION_EQUALS):
+    def __init__(self, option: str = SSMFilter.OPTION_EQUALS) -> None:
         super().__init__(self.KEY_KEYID, option)
 
 
 class SSMFilterPath(SSMFilter):
-    def __init__(self, option=SSMFilter.OPTION_RECURSIVE):
+    def __init__(self, option: str = SSMFilter.OPTION_RECURSIVE) -> None:
         super().__init__(self.KEY_PATH, option)
         raise NotImplementedError("Not implemented yet (by AWS)")

--- a/ssm_cache/groups.py
+++ b/ssm_cache/groups.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
 from ssm_cache.exceptions import (
     InvalidParameterError,
     InvalidPathError,
@@ -12,21 +17,26 @@ from ssm_cache.refreshable import Refreshable
 class SSMParameterGroup(Refreshable):
     """Concrete class that wraps multiple SSM Parameters."""
 
-    def __init__(self, max_age=None, with_decryption=True, base_path=""):
+    def __init__(
+        self,
+        max_age: int | None = None,
+        with_decryption: bool = True,
+        base_path: str = "",
+    ) -> None:
         super().__init__(max_age)
 
         self._with_decryption = with_decryption
-        self._parameters = {}
+        self._parameters: dict[str, SSMParameter] = {}
         self._base_path = base_path or ""
 
         self._validate_path(base_path)
 
     @staticmethod
-    def _validate_path(path):
+    def _validate_path(path: str) -> None:
         if path and not path.startswith("/"):
             raise InvalidPathError(f"Invalid path: {path} (should start with a slash)")
 
-    def parameter(self, path, add_prefix=True):
+    def parameter(self, path: str, add_prefix: bool = True) -> SSMParameter:
         if path in self._parameters:
             return self._parameters[path]
 
@@ -41,7 +51,12 @@ class SSMParameterGroup(Refreshable):
 
         return parameter
 
-    def parameters(self, path, recursive=True, filters=None):
+    def parameters(
+        self,
+        path: str,
+        recursive: bool = True,
+        filters: Sequence[Any] | None = None,
+    ) -> list[SSMParameter]:
         self._validate_path(path)
 
         if self._base_path:
@@ -68,9 +83,9 @@ class SSMParameterGroup(Refreshable):
 
         return parameters
 
-    def secret(self, name):
+    def secret(self, name: str) -> SecretsManagerParameter:
         if name in self._parameters:
-            return self._parameters[name]
+            return self._parameters[name]  # type: ignore[return-value]
 
         parameter = SecretsManagerParameter(name)
         parameter._group = self
@@ -79,7 +94,7 @@ class SSMParameterGroup(Refreshable):
 
         return parameter
 
-    def _refresh(self):
+    def _refresh(self) -> None:
         names = [param.full_name for param in self.get_loaded_parameters()]
 
         items, invalid_names = self._get_parameters(
@@ -99,8 +114,8 @@ class SSMParameterGroup(Refreshable):
                 version=items[parameter.name]["Version"],
             )
 
-    def get_loaded_parameters(self):
+    def get_loaded_parameters(self) -> Iterable[SSMParameter]:
         return self._parameters.values()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._parameters)

--- a/ssm_cache/parameters.py
+++ b/ssm_cache/parameters.py
@@ -1,14 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ssm_cache.exceptions import (
     InvalidParameterError,
     InvalidVersionError,
 )
 from ssm_cache.refreshable import Refreshable
 
+if TYPE_CHECKING:
+    from ssm_cache.groups import SSMParameterGroup
+
 
 class SSMParameter(Refreshable):
     """Concrete class for an individual SSM Parameter."""
 
-    def __init__(self, param_name, max_age=None, with_decryption=True):
+    def __init__(
+        self,
+        param_name: str,
+        max_age: int | None = None,
+        with_decryption: bool = True,
+    ) -> None:
         super().__init__(max_age)
 
         if not param_name:
@@ -20,37 +32,39 @@ class SSMParameter(Refreshable):
             self._is_pinned_version,
         ) = self._parse_version(param_name)
 
-        self._value = None
+        self._value: str | list[str] | None = None
         self._with_decryption = with_decryption
-        self._group = None
+        self._group: SSMParameterGroup | None = None
 
-    def load(self, value, version):
+    def load(self, value: str | list[str], version: int | None) -> None:
         """Load parameter values without direct protected mutation."""
         self._value = value
         self._version = version
 
     @staticmethod
-    def _parse_version(param_name):
-        name, version, is_pinned_version = param_name, None, False
+    def _parse_version(param_name: str) -> tuple[str, int | None, bool]:
+        name: str = param_name
+        version: int | None = None
+        is_pinned_version = False
 
         if ":" in param_name:
-            name, version = param_name.split(":")
+            name, version_str = param_name.split(":")
 
-            if version.isdigit() and int(version) > 0:
-                version = int(version)
+            if version_str.isdigit() and int(version_str) > 0:
+                version = int(version_str)
                 is_pinned_version = True
             else:
-                raise InvalidVersionError(f"Invalid version: {version}")
+                raise InvalidVersionError(f"Invalid version: {version_str}")
 
         return name, version, is_pinned_version
 
-    def _should_refresh(self):
+    def _should_refresh(self) -> bool:
         if self._group:
             return self._group._should_refresh()
 
         return super()._should_refresh()
 
-    def _refresh(self):
+    def _refresh(self) -> None:
         if self._group:
             self._group.refresh()
 
@@ -68,25 +82,25 @@ class SSMParameter(Refreshable):
         )
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
         if self._version and self._is_pinned_version:
             return f"{self._name}:{self._version}"
 
         return self._name
 
     @property
-    def version(self):
+    def version(self) -> int | None:
         if self._version is None or self._should_refresh():
             self.refresh()
 
         return self._version
 
     @property
-    def value(self):
+    def value(self) -> str | list[str] | None:
         if self._value is None or self._should_refresh():
             self.refresh()
 
@@ -96,12 +110,17 @@ class SSMParameter(Refreshable):
 class SecretsManagerParameter(SSMParameter):
     PREFIX = "/aws/reference/secretsmanager/"
 
-    def __init__(self, param_name, max_age=None, with_decryption=True):
+    def __init__(
+        self,
+        param_name: str,
+        max_age: int | None = None,
+        with_decryption: bool = True,
+    ) -> None:
         param_name = self._add_prefix(param_name)
         super().__init__(param_name, max_age, with_decryption)
 
     @classmethod
-    def _add_prefix(cls, param_name):
+    def _add_prefix(cls, param_name: str) -> str:
         if not param_name:
             raise ValueError("Secret name can't be empty")
 

--- a/ssm_cache/refreshable.py
+++ b/ssm_cache/refreshable.py
@@ -1,5 +1,9 @@
-from datetime import timedelta
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime, timedelta
 from functools import wraps
+from typing import Any, ClassVar
 
 import botocore.exceptions
 
@@ -10,10 +14,10 @@ from ssm_cache.utils import batch, utcnow
 class Refreshable:
     """Abstract class for refreshable objects (with max-age)."""
 
-    _ssm_client = None
+    _ssm_client: ClassVar[Any] = None
 
     @classmethod
-    def set_ssm_client(cls, client):
+    def set_ssm_client(cls, client: Any) -> None:
         required_methods = ("get_parameters", "get_parameters_by_path")
 
         for method in required_methods:
@@ -23,7 +27,7 @@ class Refreshable:
         cls._ssm_client = client
 
     @classmethod
-    def _get_ssm_client(cls):
+    def _get_ssm_client(cls) -> Any:
         if cls._ssm_client is None:
             import boto3
 
@@ -31,15 +35,15 @@ class Refreshable:
 
         return cls._ssm_client
 
-    def __init__(self, max_age):
-        self._last_refresh_time = None
+    def __init__(self, max_age: int | None) -> None:
+        self._last_refresh_time: datetime | None = None
         self._max_age = max_age
         self._max_age_delta = timedelta(seconds=max_age or 0)
 
-    def _refresh(self):
+    def _refresh(self) -> None:
         raise NotImplementedError
 
-    def _should_refresh(self):
+    def _should_refresh(self) -> bool:
         if not self._max_age:
             return False
 
@@ -48,7 +52,7 @@ class Refreshable:
 
         return utcnow() > self._last_refresh_time + self._max_age_delta
 
-    def _update_refresh_time(self, keep_oldest_value=False):
+    def _update_refresh_time(self, keep_oldest_value: bool = False) -> None:
         now = utcnow()
 
         if keep_oldest_value and self._last_refresh_time:
@@ -56,21 +60,25 @@ class Refreshable:
         else:
             self._last_refresh_time = now
 
-    def refresh(self):
+    def refresh(self) -> None:
         self._refresh()
         self._update_refresh_time()
 
     @staticmethod
-    def _parse_value(param_value, param_type):
+    def _parse_value(param_value: str, param_type: str) -> str | list[str]:
         if param_type == "StringList":
             return param_value.split(",")
 
         return param_value
 
     @classmethod
-    def _get_parameters(cls, names, with_decryption):
-        items = {}
-        invalid_names = []
+    def _get_parameters(
+        cls,
+        names: Sequence[str],
+        with_decryption: bool,
+    ) -> tuple[dict[str, dict[str, Any]], list[str]]:
+        items: dict[str, dict[str, Any]] = {}
+        invalid_names: list[str] = []
 
         for name_batch in batch(names, 10):
             try:
@@ -100,17 +108,17 @@ class Refreshable:
     @classmethod
     def _get_parameters_by_path(
         cls,
-        with_decryption,
-        path,
-        recursive=True,
-        filters=None,
-    ):
-        items = {}
+        with_decryption: bool,
+        path: str,
+        recursive: bool = True,
+        filters: Sequence[Any] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        items: dict[str, dict[str, Any]] = {}
 
         client = cls._get_ssm_client()
         has_builtin_paginator = hasattr(client, "get_paginator")
 
-        def serialize_filter(filter_obj):
+        def serialize_filter(filter_obj: Any) -> Any:
             if isinstance(filter_obj, SSMFilter):
                 return filter_obj.to_dict()
 
@@ -144,16 +152,16 @@ class Refreshable:
 
     def refresh_on_error(
         self,
-        error_class=Exception,
-        error_callback=None,
-        retry_argument="is_retry",
-    ):
+        error_class: type[BaseException] = Exception,
+        error_callback: Callable[[], Any] | None = None,
+        retry_argument: str | None = "is_retry",
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         if error_callback and not callable(error_callback):
             raise TypeError("error_callback must be callable")
 
-        def true_decorator(func):
+        def true_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             @wraps(func)
-            def wrapped(*args, **kwargs):
+            def wrapped(*args: Any, **kwargs: Any) -> Any:
                 try:
                     return func(*args, **kwargs)
                 except error_class:

--- a/ssm_cache/utils.py
+++ b/ssm_cache/utils.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
-def utcnow():
+def utcnow() -> datetime:
     """Return the current UTC time as a timezone-aware datetime."""
     return datetime.now(timezone.utc)
 
 
-def batch(iterable, num):
+def batch(iterable: Sequence[T], num: int) -> Iterator[Sequence[T]]:
     """Turn iterable into batches of size num."""
     length = len(iterable)
 


### PR DESCRIPTION
As offered in #51 — a focused, self-contained follow-up to #50.

Adds type annotations across the package and a `py.typed` marker so downstream users get type information (PEP 561).

### What's included
- Type hints on all modules (`utils`, `filters`, `refreshable`, `parameters`, `groups`)
- `from __future__ import annotations` so annotations stay valid on Python 3.8+ and self-referencing return types work
- `ssm_cache/py.typed` marker, shipped via setuptools `package-data` (verified present in the built wheel)
- `mypy` as a dev dependency, configured in `[tool.mypy]`, run as a new **Check types** step in the CI lint job
- One small behaviour-preserving tweak to `_parse_version` so the local stays `int | None` throughout

### Notes
- No new runtime dependencies.
- mypy is clean and the existing test suite passes unchanged (90 tests).
- Per your note in #51, I've intentionally left out release/publishing automation.

Happy to split this further or adjust anything to taste.
